### PR TITLE
SQL CASE PIVOT TABLE

### DIFF
--- a/WorkUpServer/src/main/resources/case-data.sql
+++ b/WorkUpServer/src/main/resources/case-data.sql
@@ -3,3 +3,9 @@ INSERT IGNORE INTO house (house_id, region) VALUES(2, 'NORTH');
 INSERT IGNORE INTO house (house_id, region) VALUES(3, 'EAST');
 INSERT IGNORE INTO house (house_id, region) VALUES(4, 'SOUTH');
 INSERT IGNORE INTO house (house_id, region) VALUES(5, 'WEST');
+
+INSERT IGNORE INTO city (city, population) VALUES('YAMAGATA',1028000);
+INSERT IGNORE INTO city (city, population) VALUES('HOKKAIDO', 5112000);
+INSERT IGNORE INTO city (city, population) VALUES('TOKYO', 14180000);
+INSERT IGNORE INTO city (city, population) VALUES('NAGASAKI', 1290000);
+INSERT IGNORE INTO city (city, population) VALUES('OKINAWA', 1466705);

--- a/WorkUpServer/src/main/resources/case-schema.sql
+++ b/WorkUpServer/src/main/resources/case-schema.sql
@@ -3,3 +3,10 @@ CREATE TABLE IF NOT EXISTS house (
     house_id INTEGER NOT NULL PRIMARY KEY,
     region CHAR(32) NOT NULL
 );
+
+-- city case テスト用
+CREATE TABLE IF NOT EXISTS city (
+    population INTEGER NOT NULL,
+    city CHAR(32) NOT NULL,
+    CONSTRAINT pk_City PRIMARY KEY (city)
+);


### PR DESCRIPTION
### ピボットテーブルというもの

大量のデータ分析・視覚化で使われ、好きなデータでグルーピングして合計や平均を簡単に算出できる
CASE分でこれを表現できる. 

行列の変換をする

集約するための SUM 関数

```sql
SELECT SUM(CASE WHEN city='YAMAGATA' THEN population ELSE 0 END ) AS 'YAMAGATA',
       SUM(CASE WHEN city='HOKKAIDO' THEN population ELSE 0 END ) AS 'HOKKAIDO',
       SUM(CASE WHEN city='TOKYO' THEN population ELSE 0 END ) AS 'TOKYO',
       SUM(CASE WHEN city='OKINAWA' THEN population ELSE 0 END ) AS 'OKINAWA'
FROM city;
```

自分の行以外は 0 として出力し、結果をSUMすることで 集約して出力している
```sql
mysql> SELECT SUM(CASE WHEN city='YAMAGATA' THEN population ELSE 0 END ) AS 'YAMAGATA',
    ->        SUM(CASE WHEN city='HOKKAIDO' THEN population ELSE 0 END ) AS 'HOKKAIDO',
    ->        SUM(CASE WHEN city='TOKYO' THEN population ELSE 0 END ) AS 'TOKYO',
    ->        SUM(CASE WHEN city='OKINAWA' THEN population ELSE 0 END ) AS 'OKINAWA'
    -> FROM city;
+----------+----------+----------+---------+
| YAMAGATA | HOKKAIDO | TOKYO    | OKINAWA |
+----------+----------+----------+---------+
|  1028000 |  5112000 | 14180000 | 1466705 |
+----------+----------+----------+---------+
1 row in set (0.01 sec)
```